### PR TITLE
Modifying log contents in mem0

### DIFF
--- a/embedchain/embedchain/embedder/nvidia.py
+++ b/embedchain/embedchain/embedder/nvidia.py
@@ -19,7 +19,7 @@ class NvidiaEmbedder(BaseEmbedder):
         super().__init__(config=config)
 
         model = self.config.model or "nvolveqa_40k"
-        logger.info(f"Using NVIDIA embedding model: {model}")
+        logger.info("Using NVIDIA embedding model", model=model)
         embedder = NVIDIAEmbeddings(model=model)
         embedding_fn = BaseEmbedder._langchain_default_concept(embedder)
         self.set_embedding_fn(embedding_fn=embedding_fn)


### PR DESCRIPTION
- The original logging statement used string interpolation (f-string) which violates the 'No String Interpolation' standard. The rewritten statement addresses this issue by separating the message into a string literal and passing the 'model' variable as a named parameter. This approach adheres to logging standards by avoiding string interpolation and providing structured logging. The 'info' level is maintained as it seems appropriate for logging the model being used, which is informational and not an error or warning condition.


Created by Patchwork Technologies.